### PR TITLE
Refactor back button blocks in core templates

### DIFF
--- a/templates/core/base_page.html
+++ b/templates/core/base_page.html
@@ -6,15 +6,8 @@
     {% block page_header %}
     <div class="mb-6">
       {% block back_button %}
-      {% block back_url %}{% endblock %}
-      {% if back_url %}
-        <a href="{% block back_url_link %}{% url back_url %}{% endblock %}" class="btn btn-ghost btn-sm mb-4">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-          </svg>
-          {% block back_text %}Back{% endblock %}
-        </a>
-      {% endif %}
+      {% block back_url_link %}{% endblock %}
+      {% block back_text %}Back{% endblock %}
       {% endblock %}
       <h1 class="text-4xl font-bold text-primary mb-2">{% block page_title %}Page Title{% endblock %}</h1>
       {% block page_subtitle %}{% endblock %}

--- a/templates/core/create_file.html
+++ b/templates/core/create_file.html
@@ -3,9 +3,14 @@
 {% block title %}Create File - {{ disk.name }}{% endblock %}
 {% block container_class %}max-w-2xl{% endblock %}
 
-{% block back_url %}core:disk_stats{% endblock %}
-{% block back_url_link %}{% url 'core:disk_stats' disk.name %}{% endblock %}
-{% block back_text %}Back to Disk Stats{% endblock %}
+{% block back_button %}
+<a href="{% url 'core:disk_stats' disk.name %}" class="btn btn-ghost btn-sm mb-4">
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+  </svg>
+  Back to Disk Stats
+</a>
+{% endblock %}
 {% block page_title %}Create File{% endblock %}
 {% block page_subtitle %}<p class="text-lg text-base-content/70">Add a new file to {{ disk.name }}</p>{% endblock %}
 

--- a/templates/core/disk_stats.html
+++ b/templates/core/disk_stats.html
@@ -3,8 +3,14 @@
 {% block title %}Disk Stats - {{ disk.name }}{% endblock %}
 {% block container_class %}max-w-4xl{% endblock %}
 
-{% block back_url %}core:home{% endblock %}
-{% block back_text %}Back to Home{% endblock %}
+{% block back_button %}
+<a href="{% url 'core:home' %}" class="btn btn-ghost btn-sm mb-4">
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+  </svg>
+  Back to Home
+</a>
+{% endblock %}
 {% block page_title %}Disk Statistics{% endblock %}
 {% block page_subtitle %}<p class="text-lg text-base-content/70">{{ disk.name }}</p>{% endblock %}
 


### PR DESCRIPTION
Simplified and unified the implementation of back buttons in base_page.html, create_file.html, and disk_stats.html by moving the button markup into the child templates and removing the back_url and back_url_link blocks. This change improves clarity and flexibility for customizing back buttons in individual pages.